### PR TITLE
일정 상세보기 상태관리, 스타일 개선, 달력, 페이지 타이틀 변경, 코드 리팩토링

### DIFF
--- a/src/components/Calendar/CalendarView.tsx
+++ b/src/components/Calendar/CalendarView.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { EventContentArg, EventInput, EventClickArg } from '@fullcalendar/core';
+import { EventContentArg, EventInput, DatesSetArg } from '@fullcalendar/core';
 import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import timeGridPlugin from '@fullcalendar/timegrid';
@@ -26,7 +26,7 @@ function CalendarView() {
   const router = useRouter();
   const allEvents: EventInput[] = [];
 
-  const handleDatesSet = (eventInfo: EventClickArg) => {
+  const handleDatesSet = (eventInfo: DatesSetArg) => {
     const calendarApi = eventInfo.view.calendar;
     const currentDate = calendarApi.getDate();
     const years: number = Number(dayjs(currentDate).format('YYYY'));
@@ -64,8 +64,12 @@ function CalendarView() {
     const event = allEvents.find((e) => e.id === eventContent.event.id);
     if (!event) return null;
 
+    const handleEventClick = () => {
+      alert(`${eventContent.event.title}의 상세보기는 보고싶은 날의 빈 공간을 클릭하여 확인할 수 있습니다`);
+    };
+
     return (
-      <S.EventWrapper key={event.id} color={event.priority}>
+      <S.EventWrapper key={event.id} color={event.priority} onClick={handleEventClick}>
         <S.EventTitle>{eventContent.event.title}</S.EventTitle>
         <S.EventTime>{eventContent.timeText}</S.EventTime>
       </S.EventWrapper>
@@ -74,24 +78,29 @@ function CalendarView() {
 
   return (
     <S.Container>
-      <S.CalendarWrapper>
-        <FullCalendar
-          ref={calendarRef}
-          plugins={plugins}
-          themeSystem="bootstrap5"
-          headerToolbar={headerToolbar}
-          initialView="dayGridMonth"
-          selectable={true}
-          selectMirror={true}
-          dayMaxEvents={1}
-          dayMaxEventRows={10}
-          eventContent={renderEventContent}
-          dateClick={useHandleDateClick}
-          navLinks={true}
-          events={allEvents}
-          datesSet={handleDatesSet}
-        />
-      </S.CalendarWrapper>
+      {isLoading ? (
+        <S.SkeletonWrapper></S.SkeletonWrapper>
+      ) : (
+        <S.CalendarWrapper>
+          <FullCalendar
+            height="1100px"
+            ref={calendarRef}
+            plugins={plugins}
+            themeSystem="bootstrap5"
+            headerToolbar={headerToolbar}
+            initialView="dayGridMonth"
+            selectable={true}
+            selectMirror={true}
+            dayMaxEvents={3}
+            dayMaxEventRows={10}
+            eventContent={renderEventContent}
+            dateClick={useHandleDateClick}
+            navLinks={true}
+            events={allEvents}
+            datesSet={handleDatesSet}
+          />
+        </S.CalendarWrapper>
+      )}
     </S.Container>
   );
 }

--- a/src/components/Calendar/CalendarView.tsx
+++ b/src/components/Calendar/CalendarView.tsx
@@ -15,7 +15,7 @@ import { useCalendarState } from '@/store/calendarStore';
 
 function CalendarView() {
   const calendarRef = useRef<FullCalendar>(null);
-  const { setYearStore, setMonthStore, setDateStore, getYearStore, getMonthStore, getDateStore } = useCalendarState();
+  const { setYearStore, setMonthStore, setDateStore, getYearStore, getMonthStore } = useCalendarState();
 
   const headerToolbar = {
     left: 'dayGridMonth,timeGridWeek,timeGridDay',
@@ -38,13 +38,20 @@ function CalendarView() {
   const { data: events, isLoading } = useGetCalendarAPI(getYearStore(), getMonthStore());
 
   if (events) {
-    const datas: EventInput[] = events.data.map((event: any) => ({
-      id: event.taskId.toString(),
-      title: event.title,
-      start: event.startAt,
-      end: event.endAt,
-      priority: event.priority,
-    }));
+    const datas: EventInput[] = events.data.map((event: any) => {
+      const start = event.startAt;
+      const end = event.endAt;
+      const isAllDay = dayjs(start).format('HH:mm:ss') === '00:00:00' && dayjs(end).format('HH:mm:ss') === '00:00:00';
+
+      return {
+        id: event.taskId.toString(),
+        title: event.title,
+        start: isAllDay ? start : new Date(start),
+        end: isAllDay ? dayjs(end).add(1, 'day').toDate() : new Date(end),
+        allDay: isAllDay,
+        priority: event.priority,
+      };
+    });
     allEvents.push(...datas);
   }
 
@@ -77,6 +84,7 @@ function CalendarView() {
           selectable={true}
           selectMirror={true}
           dayMaxEvents={1}
+          dayMaxEventRows={10}
           eventContent={renderEventContent}
           dateClick={useHandleDateClick}
           navLinks={true}

--- a/src/components/CommonHeader/CommonHeader.tsx
+++ b/src/components/CommonHeader/CommonHeader.tsx
@@ -9,12 +9,19 @@ import { useUserInfo } from '@/store/userInfoStore';
 import Link from 'next/link';
 import LogoutModal from './LogoutModal';
 import { TeamEnum } from '@/utils';
+import { useOverViewState } from '@/store/overViewStore';
 
 function CommonHeader() {
   const { userInfo } = useUserInfo();
+  const overViewState = useOverViewState();
   // console.log('userInfo>>', userInfo);
 
   const { isOpen, onOpen, onClose } = useDisclosure();
+
+  function handleCalendarLinkClick() {
+    overViewState.setSelectedProgress('All');
+    overViewState.setDisplayedData(null);
+  }
 
   return (
     <C.Container>
@@ -29,7 +36,9 @@ function CommonHeader() {
               <Link href={`/kanban`}>Kanban</Link>
             </li>
             <li>
-              <Link href={`/calendar`}>Calendar</Link>
+              <Link href={`/calendar`} onClick={handleCalendarLinkClick}>
+                Calendar
+              </Link>
             </li>
           </ul>
           {/* <C.CreateTaskButton>New Task</C.CreateTaskButton> */}

--- a/src/components/OverView/Content.tsx
+++ b/src/components/OverView/Content.tsx
@@ -1,25 +1,38 @@
 import React from 'react';
 import * as S from '@/styles/overview.styles';
 import { useOverViewState } from '@/store/overViewStore';
+import { OverViewProps, TaskOverviewProps } from '@/type/componentProps';
 
-function Content({ content }: any) {
+function Content({ content, isLoading }: OverViewProps) {
   const { displayedData } = useOverViewState();
   const data = displayedData ? displayedData : content;
   return (
     <S.OverViewContent>
-      {data.map((event: any) => {
-        return (
-          <S.Cards variant={'outline'} key={event.id}>
-            <S.CardWrapper>
-              <S.CardTitle>{event.title}</S.CardTitle>
-              <S.AvatarWrapper>
-                <S.CardAvatar size='md' assignee={event.assignee} />
-              </S.AvatarWrapper>
-              <S.CardBadge color={event.progress}>{event.progress}</S.CardBadge>
-            </S.CardWrapper>
-          </S.Cards>
-        );
-      })}
+      {isLoading ? (
+        <>
+          <S.CardSkeleton></S.CardSkeleton>
+          <S.CardSkeleton></S.CardSkeleton>
+          <S.CardSkeleton></S.CardSkeleton>
+          <S.CardSkeleton></S.CardSkeleton>
+          <S.CardSkeleton></S.CardSkeleton>
+        </>
+      ) : (
+        <>
+          {data.map((event: TaskOverviewProps) => {
+            return (
+              <S.Cards variant={'outline'} key={event.id}>
+                <S.CardWrapper>
+                  <S.CardTitle>{event.title}</S.CardTitle>
+                  <S.AvatarWrapper>
+                    <S.CardAvatar size="md" assignee={event.assignee} />
+                  </S.AvatarWrapper>
+                  <S.CardBadge color={event.progress}>{event.progress}</S.CardBadge>
+                </S.CardWrapper>
+              </S.Cards>
+            );
+          })}
+        </>
+      )}
     </S.OverViewContent>
   );
 }

--- a/src/components/OverView/Content.tsx
+++ b/src/components/OverView/Content.tsx
@@ -1,23 +1,25 @@
 import React from 'react';
 import * as S from '@/styles/overview.styles';
+import { useOverViewState } from '@/store/overViewStore';
 
 function Content({ content }: any) {
+  const { displayedData } = useOverViewState();
+  const data = displayedData ? displayedData : content;
   return (
     <S.OverViewContent>
-      {content.map((event: any) => {
-          return (
-            <S.Cards variant={'outline'} key={event.id}>
-              <S.CardWrapper>
-                <S.CardTitle>{event.title}</S.CardTitle>
-                <S.AvatarWrapper>
-                  <S.CardAvatar assignee={event.assignee} />
-                </S.AvatarWrapper>
-                <S.CardBadge color={event.progress}>{event.progress}</S.CardBadge>
-              </S.CardWrapper>
-            </S.Cards>
-          )
-        })
-      }
+      {data.map((event: any) => {
+        return (
+          <S.Cards variant={'outline'} key={event.id}>
+            <S.CardWrapper>
+              <S.CardTitle>{event.title}</S.CardTitle>
+              <S.AvatarWrapper>
+                <S.CardAvatar assignee={event.assignee} />
+              </S.AvatarWrapper>
+              <S.CardBadge color={event.progress}>{event.progress}</S.CardBadge>
+            </S.CardWrapper>
+          </S.Cards>
+        );
+      })}
     </S.OverViewContent>
   );
 }

--- a/src/components/OverView/Content.tsx
+++ b/src/components/OverView/Content.tsx
@@ -13,7 +13,7 @@ function Content({ content }: any) {
             <S.CardWrapper>
               <S.CardTitle>{event.title}</S.CardTitle>
               <S.AvatarWrapper>
-                <S.CardAvatar assignee={event.assignee} />
+                <S.CardAvatar size='md' assignee={event.assignee} />
               </S.AvatarWrapper>
               <S.CardBadge color={event.progress}>{event.progress}</S.CardBadge>
             </S.CardWrapper>

--- a/src/components/OverView/Header.tsx
+++ b/src/components/OverView/Header.tsx
@@ -2,41 +2,68 @@ import React from 'react';
 import * as S from '@/styles/overview.styles';
 import { Tabs, TabList } from '@chakra-ui/react';
 import { useOverViewState } from '@/store/overViewStore';
+import { OverViewProps, TaskOverviewProps } from '@/type/componentProps';
 
-function Header({ date, data }: { date: any; data: any }) {
-  const allCount = data.length;
-  const todoCount = data.filter((event: any) => event.progress === 'TODO').length;
-  const inProgressCount = data.filter((event: any) => event.progress === 'IN_PROGRESS').length;
-  const doneCount = data.filter((event: any) => event.progress === 'DONE').length;
+function Header({ date, content, isLoading }: OverViewProps) {
+  const allCount:number = content.length;
+  const todoCount:number = getCountByProgress('TODO');
+  const inProgressCount:number = getCountByProgress('IN_PROGRESS');
+  const doneCount:number = getCountByProgress('DONE');
+
+  function getCountByProgress(progress: string) {
+    return content.filter((event: TaskOverviewProps) => event.progress === progress).length;
+  }
   const { selectedProgress, setSelectedProgress, setDisplayedData } = useOverViewState();
 
   const handleTabClick = (progress: string) => {
     setSelectedProgress(progress);
-    if (progress === 'All') {
-      setDisplayedData(data);
-    } else {
-      setDisplayedData(data.filter((event: any) => event.progress === progress));
-    }
+    const filteredData = progress === 'All' ? content : content.filter((event: TaskOverviewProps) => event.progress === progress);
+    setDisplayedData(filteredData);
   };
 
   return (
     <S.OverViewHeader>
-      <S.OverViewDate>{date}</S.OverViewDate>
+      <S.OverViewDate>
+        {isLoading ? (
+          <>
+            <S.DateSkeleton></S.DateSkeleton>
+          </>
+        ) : (
+          <>{date}</>
+        )}
+      </S.OverViewDate>
       <S.OverViewSorted>
         <Tabs variant="soft-rounded">
           <TabList>
-            <S.OverViewTab onClick={() => handleTabClick('All')} aria-selected={selectedProgress === 'All'}>
-              All<S.IndexCount>{allCount}</S.IndexCount>
-            </S.OverViewTab>
-            <S.OverViewTab onClick={() => handleTabClick('TODO')} aria-selected={selectedProgress === 'TODO'}>
-              TODO<S.IndexCount>{todoCount}</S.IndexCount>
-            </S.OverViewTab>
-            <S.OverViewTab onClick={() => handleTabClick('IN_PROGRESS')} aria-selected={selectedProgress === 'IN_PROGRESS'}>
-              IN_PROGRESS<S.IndexCount>{inProgressCount}</S.IndexCount>
-            </S.OverViewTab>
-            <S.OverViewTab onClick={() => handleTabClick('DONE')} aria-selected={selectedProgress === 'DONE'}>
-              DONE<S.IndexCount>{doneCount}</S.IndexCount>
-            </S.OverViewTab>
+            {isLoading ? (
+              <>
+                <S.TabSkeleton></S.TabSkeleton>
+                <S.TabSkeleton></S.TabSkeleton>
+                <S.TabSkeleton></S.TabSkeleton>
+                <S.TabSkeleton></S.TabSkeleton>
+              </>
+            ) : (
+              <>
+                {['All', 'TODO', 'IN_PROGRESS', 'DONE'].map((progress) => (
+                  <S.OverViewTab
+                    key={progress}
+                    onClick={() => handleTabClick(progress)}
+                    aria-selected={selectedProgress === progress}
+                  >
+                    {progress}
+                    <S.IndexCount>
+                      {progress === 'All'
+                        ? allCount
+                        : progress === 'TODO'
+                        ? todoCount
+                        : progress === 'IN_PROGRESS'
+                        ? inProgressCount
+                        : doneCount}
+                    </S.IndexCount>
+                  </S.OverViewTab>
+                ))}
+              </>
+            )}
           </TabList>
         </Tabs>
       </S.OverViewSorted>

--- a/src/components/OverView/Header.tsx
+++ b/src/components/OverView/Header.tsx
@@ -8,7 +8,16 @@ function Header({ date, data }: { date: any; data: any }) {
   const todoCount = data.filter((event: any) => event.progress === 'TODO').length;
   const inProgressCount = data.filter((event: any) => event.progress === 'IN_PROGRESS').length;
   const doneCount = data.filter((event: any) => event.progress === 'DONE').length;
-  // const { getTODOStore, getIN_PROGRESSStore, getDONEStore } = useOverViewState();
+  const { selectedProgress, setSelectedProgress, setDisplayedData } = useOverViewState();
+
+  const handleTabClick = (progress: string) => {
+    setSelectedProgress(progress);
+    if (progress === 'All') {
+      setDisplayedData(data);
+    } else {
+      setDisplayedData(data.filter((event: any) => event.progress === progress));
+    }
+  };
 
   return (
     <S.OverViewHeader>
@@ -16,16 +25,16 @@ function Header({ date, data }: { date: any; data: any }) {
       <S.OverViewSorted>
         <Tabs variant="soft-rounded">
           <TabList>
-            <S.OverViewTab>
+            <S.OverViewTab onClick={() => handleTabClick('All')} aria-selected={selectedProgress === 'All'}>
               All<S.IndexCount>{allCount}</S.IndexCount>
             </S.OverViewTab>
-            <S.OverViewTab>
+            <S.OverViewTab onClick={() => handleTabClick('TODO')} aria-selected={selectedProgress === 'TODO'}>
               TODO<S.IndexCount>{todoCount}</S.IndexCount>
             </S.OverViewTab>
-            <S.OverViewTab>
+            <S.OverViewTab onClick={() => handleTabClick('IN_PROGRESS')} aria-selected={selectedProgress === 'IN_PROGRESS'}>
               IN_PROGRESS<S.IndexCount>{inProgressCount}</S.IndexCount>
             </S.OverViewTab>
-            <S.OverViewTab>
+            <S.OverViewTab onClick={() => handleTabClick('DONE')} aria-selected={selectedProgress === 'DONE'}>
               DONE<S.IndexCount>{doneCount}</S.IndexCount>
             </S.OverViewTab>
           </TabList>

--- a/src/pages/calendar/index.tsx
+++ b/src/pages/calendar/index.tsx
@@ -1,14 +1,20 @@
 import React from 'react';
 import Layout from '@/components/Layout';
 import dynamic from 'next/dynamic';
+import Head from 'next/head';
 
 const ComponentsWithNoSSR = dynamic(() => import('@/components/Calendar/CalendarView'), { ssr: false });
 
 function CalendarPage() {
   return (
-    <Layout hasHeader>
-      <ComponentsWithNoSSR />
-    </Layout>
+    <>
+      <Head>
+        <title>Need More Task · Calendar</title>
+      </Head>
+      <Layout hasHeader>
+        <ComponentsWithNoSSR />
+      </Layout>
+    </>
   );
 }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import Button from '@/components/common/CommonButton';
 import Layout from '@/components/Layout';
 import CalendarPage from './calendar/index';
 

--- a/src/pages/task/index.tsx
+++ b/src/pages/task/index.tsx
@@ -5,15 +5,17 @@ import { useGetDailyTasksAPI } from '@/apis/overview';
 import Header from '@/components/OverView/Header';
 import Content from '@/components/OverView/Content';
 import * as S from '@/styles/overview.styles';
+import Head from 'next/head';
+import { TaskOverviewProps } from '@/type/componentProps';
 
 function DailyOverview() {
   const { getDateStore } = useCalendarState();
-  const allEvents: any = [];
+  const allEvents: TaskOverviewProps[] = [];
 
   const { data: tasks, isLoading } = useGetDailyTasksAPI(getDateStore());
 
   if (tasks) {
-    const datas = tasks.data.map((event: any) => ({
+    const datas: TaskOverviewProps[] = tasks.data.map((event: TaskOverviewProps) => ({
       title: event.title,
       progress: event.progress,
       id: event.taskId.toString(),
@@ -23,12 +25,17 @@ function DailyOverview() {
   }
 
   return (
-    <Layout hasHeader>
-      <S.OverviewWrapper>
-        <Header date={getDateStore()} data={allEvents} />
-        <Content content={allEvents} />
-      </S.OverviewWrapper>
-    </Layout>
+    <>
+      <Head>
+        <title>Need More Task · Overview</title>
+      </Head>
+      <Layout hasHeader>
+        <S.OverviewWrapper>
+          <Header date={getDateStore()} content={allEvents} isLoading={isLoading} />
+          <Content content={allEvents} isLoading={isLoading} />
+        </S.OverviewWrapper>
+      </Layout>
+    </>
   );
 }
 

--- a/src/pages/task/index.tsx
+++ b/src/pages/task/index.tsx
@@ -8,7 +8,7 @@ import * as S from '@/styles/overview.styles';
 
 function DailyOverview() {
   const { getDateStore } = useCalendarState();
-  const allEvents: any=[];
+  const allEvents: any = [];
 
   const { data: tasks, isLoading } = useGetDailyTasksAPI(getDateStore());
 

--- a/src/store/overViewStore.ts
+++ b/src/store/overViewStore.ts
@@ -4,12 +4,13 @@ type OverViewState = {
   TODO: string;
   IN_PROGRESS: string;
   DONE: string;
+  selectedProgress: string;
+  displayedData: any;
 };
 
 type OverViewAction = {
-  // getTODOStore: () => MouseEventHandler<HTMLButtonElement>;
-  getIN_PROGRESSStore: () => string;
-  getDONEStore: () => string;
+  setSelectedProgress: (progress: string) => void;
+  setDisplayedData: (data: any) => void;
 };
 
 type OverViewStore = OverViewState & OverViewAction;
@@ -18,9 +19,10 @@ const overViewState = create<OverViewStore>((set, get) => ({
   TODO: 'TODO',
   IN_PROGRESS: 'IN_PROGRESS',
   DONE: 'DONE',
-  getTODOStore: () => get().TODO,
-  getIN_PROGRESSStore: () => get().IN_PROGRESS,
-  getDONEStore: () => get().DONE,
+  selectedProgress: 'All' || get().TODO || get().IN_PROGRESS || get().DONE,
+  displayedData: null,
+  setSelectedProgress: (progress: string) => set({ selectedProgress: progress }),
+  setDisplayedData: (data: any) => set({ displayedData: data }),
 }));
 
 export const useOverViewState = () => overViewState((state) => state);

--- a/src/styles/calendar.styles.ts
+++ b/src/styles/calendar.styles.ts
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import theme from './theme';
 
 export const Container = styled.div`
-  width: 1000px;
+  width: 1100px;
 `;
 
 export const CalendarWrapper = styled.div`
@@ -20,27 +20,34 @@ export const CalendarWrapper = styled.div`
     background-color: ${({ theme }) => theme.primary};
   }
   .fc .fc-daygrid-day-frame {
-    height: 100px;
+    height: 130px;
   }
   .fc {
     --fc-event-bg-color: none;
     --fc-event-border-color: none;
   }
-  .fc-daygrid-day-frame{
-    cursor:pointer;
+  .fc-daygrid-day-frame {
+    cursor: pointer;
   }
 `;
 
-export const EventTime = styled.div``;
+export const EventTime = styled.div`
+  padding: 0 5px 5px 5px;
 
-export const EventTitle = styled.div``;
+`;
+
+export const EventTitle = styled.div`
+  padding: 5px 5px 0 5px;
+`;
 
 export const EventWrapper = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  width: 100%;
-  height: 100%;
+  margin: 5px 0 5px 5px;
+  width: 99%;
+  height: 45px;
+  font-size: 12px;
   text-overflow: ellipsis;
   overflow: hidden;
   padding: 5px;

--- a/src/styles/calendar.styles.ts
+++ b/src/styles/calendar.styles.ts
@@ -1,8 +1,10 @@
 import styled from '@emotion/styled';
 import theme from './theme';
+import { Skeleton } from '@chakra-ui/react';
 
 export const Container = styled.div`
   width: 1100px;
+  height: 1130px;
 `;
 
 export const CalendarWrapper = styled.div`
@@ -20,7 +22,7 @@ export const CalendarWrapper = styled.div`
     background-color: ${({ theme }) => theme.primary};
   }
   .fc .fc-daygrid-day-frame {
-    height: 130px;
+    height: 150px;
   }
   .fc {
     --fc-event-bg-color: none;
@@ -32,22 +34,21 @@ export const CalendarWrapper = styled.div`
 `;
 
 export const EventTime = styled.div`
-  padding: 0 5px 5px 5px;
-
+  padding: 0 2px;
 `;
 
 export const EventTitle = styled.div`
-  padding: 5px 5px 0 5px;
+  padding: 0 2px;
 `;
 
 export const EventWrapper = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  margin: 5px 0 5px 5px;
+  margin: 1px 0 1px 5px;
   width: 99%;
-  height: 45px;
-  font-size: 12px;
+  height: 30px;
+  font-size: 8px;
   text-overflow: ellipsis;
   overflow: hidden;
   padding: 5px;
@@ -67,4 +68,9 @@ export const EventWrapper = styled.div`
     }
   }};
   color: ${({ theme }) => theme.white};
+`;
+
+export const SkeletonWrapper = styled(Skeleton)`
+  width: inherit;
+  height: inherit;
 `;

--- a/src/styles/overview.styles.ts
+++ b/src/styles/overview.styles.ts
@@ -113,7 +113,7 @@ export const CardBadge = styled(Badge)`
       case 'TODO':
         return theme.errorColor;
       case 'IN_PROGRESS':
-        return theme.primary;
+        return theme.warningColor;
       case 'DONE':
         return theme.successColor;
       default:

--- a/src/styles/overview.styles.ts
+++ b/src/styles/overview.styles.ts
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { Tab, Card, CardBody, Badge, Avatar } from '@chakra-ui/react';
+import { Tab, Card, CardBody, Badge, Skeleton } from '@chakra-ui/react';
 import CommonAvatar from '@/components/CommonAvatar/CommonAvatar';
 import theme from './theme';
 
@@ -8,6 +8,7 @@ export const OverviewWrapper = styled.div`
   flex-direction: column;
   align-items: center;
   width: 1200px;
+  margin-bottom: 20px;
   .chakra-tabs__tab[aria-selected='true'] {
     background-color: ${({ theme }) => theme.successColor};
     color: ${({ theme }) => theme.white};
@@ -72,7 +73,6 @@ export const OverViewContent = styled.div`
 `;
 export const Cards = styled(Card)`
   margin: 15px;
-  
 `;
 export const CardWrapper = styled(CardBody)`
   display: flex;
@@ -121,4 +121,32 @@ export const CardBadge = styled(Badge)`
     }
   }};
   color: ${({ theme }) => theme.white};
+`;
+
+export const TabSkeleton = styled(Skeleton)`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 30px;
+  width: 130px;
+  height: 40px;
+  margin: 0 10px;
+`;
+
+export const DateSkeleton = styled(Skeleton)`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 200px;
+  height: 40px;
+  margin: 0 10px;
+`;
+
+export const CardSkeleton = styled(Skeleton)`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 1168px;
+  height: 90px;
+  margin: 10px auto;
 `;

--- a/src/type/componentProps.ts
+++ b/src/type/componentProps.ts
@@ -1,10 +1,6 @@
 import { DraggableProvided, DroppableProvided } from 'react-beautiful-dnd';
 import { TaskData } from '@/apis/kanban';
-import { actionConstantsType, actionType, StatusType } from '@/constant/TaskOverview';
-import TFieldName, { UseFormRegister, UseFormRegisterReturn } from 'react-hook-form/dist/types/form';
-import { CreateTaskForm } from '@/components/modal/CreateTask';
-import { FieldPath, RegisterOptions } from 'react-hook-form';
-import React from 'react';
+import { actionType, StatusType } from '@/constant/TaskOverview';
 
 export interface KanbanDroppableItemProps {
   status: string;
@@ -25,47 +21,25 @@ export interface ModalActionLayoutProps {
     | { key: string; value?: StatusType | undefined };
 }
 
-// export interface getDataInterface {
-//   status: number;
-//   msg: string;
-//   data: TaskData[];
-// }
-
-// export enum StatusType {
-//   TODO = 'TODO',
-//   IN_PROGRESS = 'IN_PROGRESS',
-//   DONE = 'DONE',
-// }
-
-// export enum PriorityType {
-//   URGENT = 'urgent',
-//   HIGH = 'high',
-//   MEDIUM = 'medium',
-//   LOW = 'low',
-// }
-
-// export type TaskProgress = 'TODO' | 'IN_PROGRESS' | 'DONE';
-
-// export interface TaskData {
-//   taskId: number;
-//   taskOwner: TaskOwner;
-//   createdAt: string;
-//   updatedAt: string;
-//   startAt: Date;
-//   endAt: Date;
-//   title: string;
-//   desc: string;
-//   assignee: Assignee[];
-//   priority: PriorityType;
-//   progress: StatusType;
-// }
-
-// export interface Assignee {
-//   userId: number;
-//   profileImageURL: string;
-// }
-
 export interface ModalActionComponentProps {
   action: actionType;
   setTaskStatusHandler: (e: unknown) => void;
+}
+
+export interface OverViewProps {
+  date?: any;
+  content: any;
+  isLoading: boolean;
+}
+
+export interface TaskOverviewProps {
+  taskId: number;
+  title: string;
+  progress: string;
+  id: number;
+  assignee: Assignee[];
+}
+export interface Assignee {
+  userId: number;
+  profileImageUrl: string;
 }


### PR DESCRIPTION
- #50 , #51, #52 이슈 작업
- overview 상태관리 추가
- 달력, 일정 상세보기 스타일 개선
- 스켈레톤 ui 추가
- 설정된 일정에 따라 달력에서 하루종일 일정인지 시간에 따른 일정인지 표시 추가
- 타입 추가 및 명시
- 페이지 타이틀 추가
  - 페이지 이동 시 메인 타이틀 옆에 하위 페이지 타이틀 이름도 추가(ex- Need More Task · Calendar)
- 코드 개선
  - tab에 관한 코드 간단하게 변경
- 사용자 경험 개선
  - 달력에서 일자에 해당하는 빈 공간을 눌러야 상세 보기로 이동하기 때문에 알림창을 띄워 사용자의 혼란 방지